### PR TITLE
Implement backspace deletion for timeline items

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -31,6 +31,8 @@ import 'package:gradus/domain/repositories/timeline_items_repository.dart'
     as _i348;
 import 'package:gradus/domain/usecases/days/add_item_to_day_usecase.dart'
     as _i468;
+import 'package:gradus/domain/usecases/days/remove_item_from_day_usecase.dart'
+    as _i1004;
 import 'package:gradus/domain/usecases/days/get_days_usecase.dart' as _i214;
 import 'package:gradus/domain/usecases/days/move_item_between_days_usecase.dart'
     as _i913;
@@ -121,6 +123,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.factory<_i468.AddItemToDayUseCase>(
       () => _i468.AddItemToDayUseCase(gh<_i755.DaysRepository>()),
     );
+    gh.factory<_i1004.RemoveItemFromDayUseCase>(
+      () => _i1004.RemoveItemFromDayUseCase(gh<_i755.DaysRepository>()),
+    );
     gh.factory<_i913.MoveItemBetweenDaysUseCase>(
       () => _i913.MoveItemBetweenDaysUseCase(gh<_i755.DaysRepository>()),
     );
@@ -163,11 +168,13 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i956.WatchDaysUseCase>(),
         gh<_i913.MoveItemBetweenDaysUseCase>(),
         gh<_i468.AddItemToDayUseCase>(),
+        gh<_i1004.RemoveItemFromDayUseCase>(),
         gh<_i903.GetProjectsUseCase>(),
         gh<_i68.WatchProjectsUseCase>(),
         gh<_i654.GetProjectByIdUseCase>(),
         gh<_i939.CreateTimelineItemUseCase>(),
         gh<_i1003.UpdateTimelineItemUseCase>(),
+        gh<_i431.DeleteTimelineItemUseCase>(),
         gh<_i91.AuthService>(),
       ),
     );

--- a/lib/domain/usecases/days/remove_item_from_day_usecase.dart
+++ b/lib/domain/usecases/days/remove_item_from_day_usecase.dart
@@ -1,0 +1,27 @@
+import 'package:dartz/dartz.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../../core/error/failure.dart';
+import '../../entities/day.dart';
+import '../../repositories/days_repository.dart';
+
+@injectable
+class RemoveItemFromDayUseCase {
+  final DaysRepository _repository;
+
+  RemoveItemFromDayUseCase(this._repository);
+
+  Future<Either<Failure, Unit>> call({
+    required String itemId,
+    required Day day,
+  }) {
+    final updatedItemIds = List<String>.from(day.itemIds)..remove(itemId);
+    final updatedDay = day.copyWith(itemIds: updatedItemIds);
+    return _repository.updateDay(updatedDay).then((result) {
+      return result.fold(
+        (failure) => Left(failure),
+        (_) => const Right(unit),
+      );
+    });
+  }
+}

--- a/lib/presentation/cubits/timeline/timeline_cubit.dart
+++ b/lib/presentation/cubits/timeline/timeline_cubit.dart
@@ -10,6 +10,7 @@ import '../../../domain/usecases/days/get_days_usecase.dart';
 import '../../../domain/usecases/days/watch_days_usecase.dart';
 import '../../../domain/usecases/days/move_item_between_days_usecase.dart';
 import '../../../domain/usecases/days/add_item_to_day_usecase.dart';
+import '../../../domain/usecases/days/remove_item_from_day_usecase.dart';
 import '../../../domain/usecases/projects/get_projects_usecase.dart';
 import '../../../domain/usecases/projects/watch_projects_usecase.dart';
 import '../../../domain/usecases/projects/get_project_by_id_usecase.dart';
@@ -19,6 +20,7 @@ import '../../../domain/entities/task.dart';
 import '../../../domain/entities/note_type.dart';
 import '../../../domain/entities/timeline_item.dart';
 import '../../../domain/usecases/timeline_items/update_timeline_item_usecase.dart';
+import '../../../domain/usecases/timeline_items/delete_timeline_item_usecase.dart';
 import '../../../core/utils/text_commands.dart';
 import 'timeline_state.dart';
 
@@ -28,11 +30,13 @@ class TimelineCubit extends Cubit<TimelineState> {
   final WatchDaysUseCase _watchDaysUseCase;
   final MoveItemBetweenDaysUseCase _moveItemBetweenDaysUseCase;
   final AddItemToDayUseCase _addItemToDayUseCase;
+  final RemoveItemFromDayUseCase _removeItemFromDayUseCase;
   final GetProjectsUseCase _getProjectsUseCase;
   final WatchProjectsUseCase _watchProjectsUseCase;
   final GetProjectByIdUseCase _getProjectByIdUseCase;
   final CreateTimelineItemUseCase _createTimelineItemUseCase;
   final UpdateTimelineItemUseCase _updateTimelineItemUseCase;
+  final DeleteTimelineItemUseCase _deleteTimelineItemUseCase;
   final AuthService _authService;
 
   StreamSubscription? _daysSubscription;
@@ -47,11 +51,13 @@ class TimelineCubit extends Cubit<TimelineState> {
     this._watchDaysUseCase,
     this._moveItemBetweenDaysUseCase,
     this._addItemToDayUseCase,
+    this._removeItemFromDayUseCase,
     this._getProjectsUseCase,
     this._watchProjectsUseCase,
     this._getProjectByIdUseCase,
     this._createTimelineItemUseCase,
     this._updateTimelineItemUseCase,
+    this._deleteTimelineItemUseCase,
     this._authService,
   ) : super(const TimelineState.initial()) {
     _initializeTimeline();
@@ -547,6 +553,20 @@ class TimelineCubit extends Cubit<TimelineState> {
       (_) {
         print('✅ [TimelineCubit] Note type transformed successfully');
       }, // Items will be automatically updated through stream
+    );
+  }
+
+  Future<void> deleteItemFromDay({required String itemId, required Day day}) async {
+    final removeResult = await _removeItemFromDayUseCase(itemId: itemId, day: day);
+    await removeResult.fold(
+      (failure) async => emit(TimelineState.error(failure: failure)),
+      (_) async {
+        final deleteResult = await _deleteTimelineItemUseCase(itemId);
+        deleteResult.fold(
+          (failure) => emit(TimelineState.error(failure: failure)),
+          (_) {},
+        );
+      },
     );
   }
 

--- a/lib/presentation/widgets/shared/timeline_item_editing_mixin.dart
+++ b/lib/presentation/widgets/shared/timeline_item_editing_mixin.dart
@@ -241,12 +241,17 @@ mixin TimelineItemEditingMixin<T extends StatefulWidget> on State<T> {
       child: KeyboardListener(
         focusNode: FocusNode(),
         onKeyEvent: (KeyEvent event) {
-          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.enter) {
-            final isShiftPressed = HardwareKeyboard.instance.isShiftPressed;
-            if (!isShiftPressed) {
-              onEnterPressed(isShiftPressed: false);
+          if (event is KeyDownEvent) {
+            if (event.logicalKey == LogicalKeyboardKey.enter) {
+              final isShiftPressed = HardwareKeyboard.instance.isShiftPressed;
+              if (!isShiftPressed) {
+                onEnterPressed(isShiftPressed: false);
+              }
+            } else if (event.logicalKey == LogicalKeyboardKey.backspace) {
+              if (textController.text.isEmpty) {
+                onBackspacePressed();
+              }
             }
-            // If Shift is pressed, let the TextFormField handle it naturally
           }
         },
         child: TextFormField(
@@ -290,6 +295,11 @@ mixin TimelineItemEditingMixin<T extends StatefulWidget> on State<T> {
 
   /// Handle Enter key press
   void onEnterPressed({required bool isShiftPressed}) {
+    // Default implementation - can be overridden
+  }
+
+  /// Handle Backspace key press when text is empty
+  void onBackspacePressed() {
     // Default implementation - can be overridden
   }
 

--- a/lib/presentation/widgets/timeline/note_card.dart
+++ b/lib/presentation/widgets/timeline/note_card.dart
@@ -94,6 +94,13 @@ class _NoteCardState extends State<NoteCard> with TimelineItemEditingMixin {
   }
 
   @override
+  void onBackspacePressed() {
+    context
+        .read<TimelineCubit>()
+        .deleteItemFromDay(itemId: widget.note.id, day: widget.day);
+  }
+
+  @override
   void saveChanges(String newContent) {
     if (newContent.trim() != _originalContent && newContent.trim().isNotEmpty) {
       final updatedNote = widget.note.copyWith(content: newContent.trim());

--- a/lib/presentation/widgets/timeline/task_card.dart
+++ b/lib/presentation/widgets/timeline/task_card.dart
@@ -86,6 +86,13 @@ class _TaskCardState extends State<TaskCard> with TimelineItemEditingMixin {
   }
 
   @override
+  void onBackspacePressed() {
+    context
+        .read<TimelineCubit>()
+        .deleteItemFromDay(itemId: widget.task.id, day: widget.day);
+  }
+
+  @override
   void saveChanges(String newTitle) {
     if (newTitle.trim() != _originalTitle && newTitle.trim().isNotEmpty) {
       final updatedTask = widget.task.copyWith(title: newTitle.trim());


### PR DESCRIPTION
## Summary
- add RemoveItemFromDayUseCase
- inject removal use case and delete use case into `TimelineCubit`
- handle backspace key in `TimelineItemEditingMixin`
- delete notes and tasks when backspace is pressed on empty content

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad63f6b14832ab87aa6a648d7b0ed